### PR TITLE
support duplicate tags during resend

### DIFF
--- a/in_session.go
+++ b/in_session.go
@@ -238,7 +238,7 @@ func (state inSession) resendMessages(session *session, beginSeqNo, endSeqNo int
 		}
 
 		session.log.OnEventf("Resending Message: %v", sentMessageSeqNum)
-		msgBytes = msg.resendBuild()
+		msgBytes = msg.buildFromBodyBytes()
 		session.EnqueueBytesAndSend(msgBytes)
 
 		seqNum = sentMessageSeqNum + 1

--- a/in_session.go
+++ b/in_session.go
@@ -238,7 +238,7 @@ func (state inSession) resendMessages(session *session, beginSeqNo, endSeqNo int
 		}
 
 		session.log.OnEventf("Resending Message: %v", sentMessageSeqNum)
-		msgBytes = msg.build()
+		msgBytes = msg.resendBuild()
 		session.EnqueueBytesAndSend(msgBytes)
 
 		seqNum = sentMessageSeqNum + 1

--- a/message.go
+++ b/message.go
@@ -373,9 +373,32 @@ func (m *Message) build() []byte {
 	return b.Bytes()
 }
 
+func (m *Message) resendBuild() []byte {
+	m.resendCook()
+
+	var b bytes.Buffer
+	m.Header.write(&b)
+	b.Write(m.bodyBytes)
+	m.Trailer.write(&b)
+	return b.Bytes()
+}
+
 func (m *Message) cook() {
 	bodyLength := m.Header.length() + m.Body.length() + m.Trailer.length()
 	m.Header.SetInt(tagBodyLength, bodyLength)
 	checkSum := (m.Header.total() + m.Body.total() + m.Trailer.total()) % 256
+	m.Trailer.SetString(tagCheckSum, formatCheckSum(checkSum))
+}
+
+func (m *Message) resendCook() {
+	bodyLength := m.Header.length() + len(m.bodyBytes) + m.Trailer.length()
+	m.Header.SetInt(tagBodyLength, bodyLength)
+
+	bodyTotal := 0
+	for _, b := range []byte(m.bodyBytes) {
+		bodyTotal += int(b)
+	}
+
+	checkSum := (m.Header.total() + bodyTotal + m.Trailer.total()) % 256
 	m.Trailer.SetString(tagCheckSum, formatCheckSum(checkSum))
 }

--- a/message.go
+++ b/message.go
@@ -373,8 +373,10 @@ func (m *Message) build() []byte {
 	return b.Bytes()
 }
 
-func (m *Message) resendBuild() []byte {
-	m.resendCook()
+// introduced to work around issue with resending messages with repeating groups
+// issue described: https://github.com/quickfixgo/quickfix/issues/276
+func (m *Message) buildFromBodyBytes() []byte {
+	m.cookFromBodyBytes()
 
 	var b bytes.Buffer
 	m.Header.write(&b)
@@ -390,7 +392,7 @@ func (m *Message) cook() {
 	m.Trailer.SetString(tagCheckSum, formatCheckSum(checkSum))
 }
 
-func (m *Message) resendCook() {
+func (m *Message) cookFromBodyBytes() {
 	bodyLength := m.Header.length() + len(m.bodyBytes) + m.Trailer.length()
 	m.Header.SetInt(tagBodyLength, bodyLength)
 

--- a/message.go
+++ b/message.go
@@ -212,14 +212,14 @@ func ParseMessageWithDataDictionary(
 			trailerBytes = rawBytes
 			msg.Body.add(msg.fields[fieldIndex : fieldIndex+1])
 		}
-		if parsedFieldBytes.tag == tagCheckSum {
-			break
-		}
 
 		if !foundBody {
 			msg.bodyBytes = rawBytes
 		}
 
+		if parsedFieldBytes.tag == tagCheckSum {
+			break
+		}
 		fieldIndex++
 	}
 

--- a/message_test.go
+++ b/message_test.go
@@ -88,6 +88,15 @@ func (s *MessageSuite) TestParseOutOfOrder() {
 	s.Nil(ParseMessage(s.msg, rawMsg))
 }
 
+func (s *MessageSuite) TestRoundtripBuildFromBodyBytes() {
+	expected := bytes.NewBufferString("8=FIX.4.29=14235=D34=143=Y49=ISLD52=20230305-21:16:44.00256=TW122=20230305-21:16:44.00211=11=tag1group12=tag2group112=11=tag1group22=tag2group210=099")
+	err := ParseMessage(s.msg, expected)
+	s.NoError(err)
+
+	actual := s.msg.buildFromBodyBytes()
+	s.Equal(expected.Bytes(), actual)
+}
+
 func (s *MessageSuite) TestBuild() {
 	s.msg.Header.SetField(tagBeginString, FIXString(BeginStringFIX44))
 	s.msg.Header.SetField(tagMsgType, FIXString("A"))


### PR DESCRIPTION
I noticed that this is actually an outstanding issue described here: https://github.com/quickfixgo/quickfix/issues/276. This PR implements the "hack" described in it. 

Obviously not ideal, but parsing out repeating groups from a raw message is a bit involved and would take more than the few hours I've thrown at this. For example, see the java logic: https://github.com/quickfix-j/quickfixj/blob/a48c11b57898d95cbfa9d32ba1be3bdee5f895fd/quickfixj-core/src/main/java/quickfix/Message.java#L711